### PR TITLE
feat: update go SDK to latest generation version

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -1,29 +1,25 @@
 name: Generate
 permissions:
-  checks: write
-  contents: write
-  pull-requests: write
-  statuses: write
+    checks: write
+    contents: write
+    pull-requests: write
+    statuses: write
 "on":
-  workflow_dispatch:
-    inputs:
-      force:
-        description: Force generation of SDKs
-        type: boolean
-        default: false
-  schedule:
-    - cron: 0 0 * * *
+    workflow_dispatch:
+        inputs:
+            force:
+                description: Force generation of SDKs
+                type: boolean
+                default: false
+    schedule:
+        - cron: 0 0 * * *
 jobs:
-  generate:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-generation.yaml@v14
-    with:
-      force: ${{ github.event.inputs.force }}
-      languages: |
-        - go
-      mode: direct
-      openapi_docs: |
-        - https://api-docs.bolt.com/api.bundle.yaml
-      speakeasy_version: 1.210.0
-    secrets:
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+    generate:
+        uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
+        with:
+            force: ${{ github.event.inputs.force }}
+            mode: direct
+            speakeasy_version: latest
+        secrets:
+            github_access_token: ${{ secrets.GITHUB_TOKEN }}
+            speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -4,7 +4,7 @@ sources:
         inputs:
             - location: https://api-docs.bolt.com/api.bundle.yaml
         overlays:
-            - ./default_error_overlay.yaml
+            - location: ./default_error_overlay.yaml
 targets:
     bolt-go:
         target: go

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,0 +1,11 @@
+workflowVersion: 1.0.0
+sources:
+    my-source:
+        inputs:
+            - location: https://api-docs.bolt.com/api.bundle.yaml
+        overlays:
+            - ./default_error_overlay.yaml
+targets:
+    bolt-go:
+        target: go
+        source: my-source

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,6 +1,6 @@
 workflowVersion: 1.0.0
 sources:
-    my-source:
+    my-go-source:
         inputs:
             - location: https://api-docs.bolt.com/api.bundle.yaml
         overlays:
@@ -8,4 +8,4 @@ sources:
 targets:
     bolt-go:
         target: go
-        source: my-source
+        source: my-go-source

--- a/default_error_overlay.yaml
+++ b/default_error_overlay.yaml
@@ -1,0 +1,38 @@
+overlay: 1.0.0
+info:
+  title: Overlay api.bundle.yaml => api.bundle2.yaml
+  version: 0.0.0
+actions:
+  - target: $["components"]["responses"]["response-4xx"]["content"]["application/json"]["schema"]["oneOf"][0]["$ref"]
+    update: '#/components/schemas/default_error'
+  - target: $["components"]["responses"]["response-address-error"]["content"]["application/json"]["schema"]["oneOf"][0]["$ref"]
+    update: '#/components/schemas/default_error'
+  - target: $["components"]["responses"]["response-payment-method-error"]["content"]["application/json"]["schema"]["oneOf"][0]["$ref"]
+    update: '#/components/schemas/default_error'
+  - target: $["components"]["responses"]["response-payment-error"]["content"]["application/json"]["schema"]["oneOf"][0]["$ref"]
+    update: '#/components/schemas/default_error'
+  - target: $["components"]["schemas"]
+    update:
+      default_error:
+        type: object
+        required:
+          - .tag
+          - message
+        properties:
+          .tag:
+            type: string
+            enum:
+              - unauthorized
+              - forbidden
+              - unprocessable_request
+              - not_found
+            description: The type of error returned
+            example: unprocessable_request
+          message:
+            type: string
+            description: |
+              A human-readable error message, which might include information specific to
+              the request that was made.
+            example: We were unable to process your request.
+  - target: $["components"]["schemas"]["error"]
+    remove: true

--- a/default_error_overlay.yaml
+++ b/default_error_overlay.yaml
@@ -3,36 +3,6 @@ info:
   title: Overlay api.bundle.yaml => api.bundle2.yaml
   version: 0.0.0
 actions:
-  - target: $["components"]["responses"]["response-4xx"]["content"]["application/json"]["schema"]["oneOf"][0]["$ref"]
-    update: '#/components/schemas/default_error'
-  - target: $["components"]["responses"]["response-address-error"]["content"]["application/json"]["schema"]["oneOf"][0]["$ref"]
-    update: '#/components/schemas/default_error'
-  - target: $["components"]["responses"]["response-payment-method-error"]["content"]["application/json"]["schema"]["oneOf"][0]["$ref"]
-    update: '#/components/schemas/default_error'
-  - target: $["components"]["responses"]["response-payment-error"]["content"]["application/json"]["schema"]["oneOf"][0]["$ref"]
-    update: '#/components/schemas/default_error'
-  - target: $["components"]["schemas"]
-    update:
-      default_error:
-        type: object
-        required:
-          - .tag
-          - message
-        properties:
-          .tag:
-            type: string
-            enum:
-              - unauthorized
-              - forbidden
-              - unprocessable_request
-              - not_found
-            description: The type of error returned
-            example: unprocessable_request
-          message:
-            type: string
-            description: |
-              A human-readable error message, which might include information specific to
-              the request that was made.
-            example: We were unable to process your request.
   - target: $["components"]["schemas"]["error"]
-    remove: true
+    update:
+      x-speakeasy-name-override: "generic-error"

--- a/gen.yaml
+++ b/gen.yaml
@@ -1,6 +1,6 @@
 configVersion: 2.0.0
 generation:
-  sdkClassName: Bolt-Typescript-SDK
+  sdkClassName: Bolt-Go-SDK
   maintainOpenAPIOrder: true
   usageSnippets:
     optionalPropertyRendering: withExample


### PR DESCRIPTION
I noticed that the Go SDK is lagging behind with latest generation features. Unlike [typescript](https://github.com/BoltApp/Bolt-Typescript-SDK) which is on the latest version.

I update the SDK repo to use workflows and generate from the latest version here.

Also I noticed there was a small go specific collision issue with a openapi field named `error` in the Bolt spec. I made a simple overlay file for this repo to change this to `default_error` in go generations. That will allow the SDK to work fine and you don't have to make any changes to https://api-docs.bolt.com/api.bundle.yaml

cc @Wolfizen @davidminin 